### PR TITLE
Add a debug property to `RMPaperTrailLogger`

### DIFF
--- a/Classes/RMPaperTrailLogger.h
+++ b/Classes/RMPaperTrailLogger.h
@@ -41,6 +41,11 @@
 @property (nonatomic, assign) BOOL useTLS;
 
 /**
+ Specifies whether the logger should emit informational NSLogs
+ */
+@property (nonatomic, assign) BOOL debug;
+
+/**
  Returns a initialized singleton instance of this logger
  */
 +(RMPaperTrailLogger *) sharedInstance;

--- a/Classes/RMPaperTrailLogger.m
+++ b/Classes/RMPaperTrailLogger.m
@@ -43,6 +43,7 @@
         RMSyslogFormatter *logFormatter = [[RMSyslogFormatter alloc] init];
         _sharedInstance.logFormatter = logFormatter;
         _sharedInstance.useTLS = YES;
+        _sharedInstance.debug = YES;
     });
 
     return _sharedInstance;
@@ -134,7 +135,9 @@
 
 #if !TARGET_OS_IPHONE
     if (self.useTLS) {
-        NSLog(@"Starting TLS");
+        if (self.debug) {
+            NSLog(@"Starting TLS");
+        }
         [self.tcpSocket startTLS:nil];
     }
 #endif
@@ -144,12 +147,16 @@
 
 - (void)socket:(GCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(UInt16)port
 {
-    NSLog(@"Socket did connect to host");
+    if (self.debug) {
+        NSLog(@"Socket did connect to host");
+    }
 }
 
 - (void)socketDidSecure:(GCDAsyncSocket *)sock
 {
-    NSLog(@"Socket did secure");
+    if (self.debug) {
+        NSLog(@"Socket did secure");
+    }
 }
 
 - (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)error
@@ -159,7 +166,9 @@
 
 - (void)socket:(GCDAsyncSocket *)sock didWriteDataWithTag:(long)tag
 {
-    NSLog(@"Socket did write data");
+    if (self.debug) {
+        NSLog(@"Socket did write data");
+    }
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PaperTrailLumberjack
 PaperTrailLumberjack is a CocoaLumberjack logger that helps log statements to your log destination at [papertrailapp](http://papertrailapp.com).
-It can log using TCP and UDP. On OS X, TLS is supported on TCP Connections, while, on iOS, TCP connections are currently only plain-text. 
-The default is UDP (which is always unencrypted). 
+It can log using TCP and UDP. On OS X, TLS is supported on TCP Connections, while, on iOS, TCP connections are currently only plain-text.
+The default is UDP (which is always unencrypted).
 
 ## Usage
 
@@ -11,7 +11,8 @@ Example UDP logging:
 
     RMPaperTrailLogger *paperTrailLogger = [RMPaperTrailLogger sharedInstance];
     paperTrailLogger.host = @"destination.papertrailapp.com"; //Your host here
-    paperTrailLogger.port = 9999; //Your port number here    
+    paperTrailLogger.port = 9999; //Your port number here
+    paperTrailLogger.debug = NO; //Silences some NSLogging
     [DDLog addLogger:paperTrailLogger];
     DDLogVerbose(@"Hi PaperTrailApp.com);
 
@@ -19,8 +20,9 @@ Example TCP logging (with TLS):
 
     RMPaperTrailLogger *paperTrailLogger = [RMPaperTrailLogger sharedInstance];
     paperTrailLogger.host = @"destination.papertrailapp.com"; //Your host here
-    paperTrailLogger.port = 9999; //Your port number here    
-    paperTrailLogger.useTcp = YES; //TLS is on by default on OS X and ignored on iOS    
+    paperTrailLogger.port = 9999; //Your port number here
+    paperTrailLogger.debug = NO; //Silences some NSLogging
+    paperTrailLogger.useTcp = YES; //TLS is on by default on OS X and ignored on iOS
     [DDLog addLogger:paperTrailLogger];
     DDLogVerbose(@"Hi PaperTrailApp.com");
 
@@ -46,4 +48,3 @@ George Malayil-Philip, [george.malayil@roguemonkey.in](mailto:george.malayil@rog
 ## License
 
 PaperTrailLumberjack is available under the MIT license. See the LICENSE file for more info.
-


### PR DESCRIPTION
The "NSLog(@"Socket did write data");" etc messages were cluttering my logs and I added an option to disable them.

If set to NO, this debug option silences the informational NSLogs that `RMPaperTrailLogger` emits. The error messages are not silenced. The default value of `debug` is `YES`, so the behaviour of the logger is unchanged unless the user sets `debug` to `NO`.

Thanks for maintaining this library!
