### PR TITLE
Enable tls support on iOS

### DIFF
--- a/Classes/RMPaperTrailLogger.m
+++ b/Classes/RMPaperTrailLogger.m
@@ -133,14 +133,12 @@
         return;
     }
 
-#if !TARGET_OS_IPHONE
     if (self.useTLS) {
         if (self.debug) {
             NSLog(@"Starting TLS");
         }
         [self.tcpSocket startTLS:nil];
     }
-#endif
 }
 
 #pragma mark - GCDAsyncDelegate methods


### PR DESCRIPTION
Does anyone know why this is disabled for iOS?

I removed the #defines and it seems to work fine. Can't see any reason why it shouldn't be allowed.
