### PR TITLE
Update to CocoaLumberjack 2.2.0

### DIFF
--- a/Classes/RMSyslogFormatter.m
+++ b/Classes/RMSyslogFormatter.m
@@ -32,7 +32,9 @@ static NSString * const RMAppUUIDKey = @"RMAppUUIDKey";
     NSString *file = [[logMessage.file lastPathComponent] stringByDeletingPathExtension];
     
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"MMM dd HH:mm:ss"];
+    NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+    [dateFormatter setLocale:enUSPOSIXLocale];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
     [dateFormatter setTimeZone:[NSTimeZone systemTimeZone]];
     NSString *timestamp = [dateFormatter stringFromDate:logMessage.timestamp];
     

--- a/Examples/PaperTrailLumberjackiOSExample/PaperTrailLumberjackiOSExample.xcodeproj/project.pbxproj
+++ b/Examples/PaperTrailLumberjackiOSExample/PaperTrailLumberjackiOSExample.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00C59928DEE38407031511EB /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		0899379D471708AF07A28F9F /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		25E14FEC191BF75E00A6F738 /* PaperTrailLumberjackiOSExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PaperTrailLumberjackiOSExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		25E14FEF191BF75E00A6F738 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		25E14FF1191BF75E00A6F738 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -64,7 +66,6 @@
 		25E15012191BF75F00A6F738 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		25E15014191BF75F00A6F738 /* PaperTrailLumberjackiOSExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PaperTrailLumberjackiOSExampleTests.m; sourceTree = "<group>"; };
 		754EB71B279344A592139E48 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		EF580ACE90864D4086CA212A /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,7 +100,7 @@
 				25E1500E191BF75F00A6F738 /* PaperTrailLumberjackiOSExampleTests */,
 				25E14FEE191BF75E00A6F738 /* Frameworks */,
 				25E14FED191BF75E00A6F738 /* Products */,
-				EF580ACE90864D4086CA212A /* Pods.xcconfig */,
+				77C7B516B3718613DF37E177 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -164,6 +165,15 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		77C7B516B3718613DF37E177 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				00C59928DEE38407031511EB /* Pods.debug.xcconfig */,
+				0899379D471708AF07A28F9F /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -176,6 +186,7 @@
 				25E14FE9191BF75E00A6F738 /* Frameworks */,
 				25E14FEA191BF75E00A6F738 /* Resources */,
 				62F6F07A53454515ACFEA610 /* Copy Pods Resources */,
+				2406866A78675B8B00C92D3B /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -259,6 +270,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2406866A78675B8B00C92D3B /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		25E15022191BFD4200A6F738 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -284,7 +310,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		AEA8D74221F645D6B2D05180 /* Check Pods Manifest.lock */ = {
@@ -426,7 +452,7 @@
 		};
 		25E15019191BF75F00A6F738 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EF580ACE90864D4086CA212A /* Pods.xcconfig */;
+			baseConfigurationReference = 00C59928DEE38407031511EB /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -440,7 +466,7 @@
 		};
 		25E1501A191BF75F00A6F738 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EF580ACE90864D4086CA212A /* Pods.xcconfig */;
+			baseConfigurationReference = 0899379D471708AF07A28F9F /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -553,6 +579,7 @@
 				25E15021191BFD3C00A6F738 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Examples/PaperTrailLumberjackiOSExample/PaperTrailLumberjackiOSExample/RMAppDelegate.m
+++ b/Examples/PaperTrailLumberjackiOSExample/PaperTrailLumberjackiOSExample/RMAppDelegate.m
@@ -16,6 +16,7 @@
     // Override point for customization after application launch.
     self.window.backgroundColor = [UIColor whiteColor];
     [self.window makeKeyAndVisible];
+    self.window.rootViewController = [UIViewController new];
     return YES;
 }
 

--- a/Examples/PaperTrailLumberjackiOSExample/PaperTrailLumberjackiOSExampleTests/PaperTrailLumberjackiOSExampleTests.m
+++ b/Examples/PaperTrailLumberjackiOSExample/PaperTrailLumberjackiOSExampleTests/PaperTrailLumberjackiOSExampleTests.m
@@ -8,13 +8,11 @@
 
 #import <XCTest/XCTest.h>
 
-#import <DDLog.h>
-#import <DDASLLogger.h>
-#import <DDTTYLogger.h>
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 #import "RMPaperTrailLogger.h"
 
-const int ddLogLevel = LOG_LEVEL_VERBOSE;
+const int ddLogLevel = DDLogLevelVerbose;
 
 @interface PaperTrailLumberjackiOSExampleTests : XCTestCase {
     RMPaperTrailLogger *_paperTrailLogger;

--- a/Examples/PaperTrailLumberjackiOSExample/Podfile.lock
+++ b/Examples/PaperTrailLumberjackiOSExample/Podfile.lock
@@ -1,13 +1,16 @@
 PODS:
-  - CocoaAsyncSocket (7.3.5)
-  - CocoaLumberjack (1.8.1):
-    - CocoaLumberjack/Extensions
-  - CocoaLumberjack/Core (1.8.1)
-  - CocoaLumberjack/Extensions (1.8.1):
+  - CocoaAsyncSocket (7.4.2)
+  - CocoaLumberjack (2.2.0):
+    - CocoaLumberjack/Default (= 2.2.0)
+    - CocoaLumberjack/Extensions (= 2.2.0)
+  - CocoaLumberjack/Core (2.2.0)
+  - CocoaLumberjack/Default (2.2.0):
     - CocoaLumberjack/Core
-  - PaperTrailLumberjack (0.1.0):
+  - CocoaLumberjack/Extensions (2.2.0):
+    - CocoaLumberjack/Default
+  - PaperTrailLumberjack (1.0.2):
     - CocoaAsyncSocket
-    - CocoaLumberjack
+    - CocoaLumberjack (~> 2.2.0)
 
 DEPENDENCIES:
   - PaperTrailLumberjack (from `../..`)
@@ -17,8 +20,8 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  CocoaAsyncSocket: a3b6de9958961578b36eabb8e921efd95b13d80c
-  CocoaLumberjack: 020378ec400d658923bf5887178394f65f052c90
-  PaperTrailLumberjack: da28204cdd8afb5a67c1a06e544efcec97d68fe3
+  CocoaAsyncSocket: f5783bdedd232d91b89769bc4b5a1580aed518ad
+  CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
+  PaperTrailLumberjack: 43b20b5a158f261d1e3b604013d8a7624a24a5ad
 
-COCOAPODS: 0.32.1
+COCOAPODS: 0.39.0

--- a/PaperTrailLumberjack.podspec
+++ b/PaperTrailLumberjack.podspec
@@ -16,6 +16,6 @@ A CocoaLumberjack logger to post log messages to papertrailapp.com. Currently, o
 
   s.source_files = 'Classes'
 
-  s.dependency 'CocoaLumberjack', '~> 2.0.0'
+  s.dependency 'CocoaLumberjack', '~> 2.2.0'
   s.dependency 'CocoaAsyncSocket'
 end


### PR DESCRIPTION
A series of updates to be compatible with CocoaLumberjack 2.2.0.
And fix the syslog format for the new Papertrail architecture.

Cheers
