### PR TITLE
Update install instructions for unofficial cocoapod

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sample log output:
 PaperTrailLumberjack is available through [CocoaPods](http://cocoapods.org), to install
 it simply add the following line to your Podfile:
 
-    pod 'PaperTrailLumberjack'
+    pod 'PaperTrailLumberjack', :git => 'https://github.com/greenbits/papertrail-lumberjack-ios.git'
 
 ## Author
 


### PR DESCRIPTION
It looks like this fork and the pod officially listed by cocoapods (http://bitbucket.org/rmonkey/papertraillumberjack) are out of sync and the install instruction installs not-this-version. This line updates the README to point at this version.
