### PR TITLE
Remove invalid metadata

### DIFF
--- a/PaperTrailLumberjack.podspec
+++ b/PaperTrailLumberjack.podspec
@@ -9,6 +9,7 @@ A CocoaLumberjack logger to post log messages to papertrailapp.com. Currently, o
   s.license          = 'MIT'
   s.author           = { "George Malayil Philip" => "george.malayil@roguemonkey.in" }
   s.source = { :git => "https://github.com/greenbits/papertrail-lumberjack-ios.git" , :tag => s.version.to_s }
+  s.platform         = :ios
 
   s.requires_arc = true
   s.ios.deployment_target = '5.0'

--- a/PaperTrailLumberjack.podspec
+++ b/PaperTrailLumberjack.podspec
@@ -11,7 +11,6 @@ A CocoaLumberjack logger to post log messages to papertrailapp.com. Currently, o
   s.source = { :git => "https://github.com/greenbits/papertrail-lumberjack-ios.git" , :tag => s.version.to_s }
 
   s.requires_arc = true
-  s.ios.platform = :ios, '5.0'
   s.ios.deployment_target = '5.0'
 
   s.source_files = 'Classes'


### PR DESCRIPTION
After updating to Cocoapods `1.0.0.beta.4` I was unable to install your library. This change to the pod spec seems to fix the issue. There are other warnings/notes (see below) but they don't seem to impact installation.

```
 -> PaperTrailLumberjack (1.0.3)
    - WARN  | xcodebuild:  PaperTrailLumberjack/Classes/RMPaperTrailLogger.m:98:84: warning: sending 'RMPaperTrailLogger *const __strong' to parameter of incompatible type 'id<GCDAsyncUdpSocketDelegate>'
    - NOTE  | xcodebuild:  CocoaAsyncSocket/Source/GCD/GCDAsyncUdpSocket.h:182:56: note: passing argument to parameter 'aDelegate' here

```
