### PR TITLE
Update RMSyslogFormatter.m

### DIFF
--- a/Classes/RMSyslogFormatter.m
+++ b/Classes/RMSyslogFormatter.m
@@ -36,7 +36,7 @@ static NSString * const RMAppUUIDKey = @"RMAppUUIDKey";
     NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
     [dateFormatter setLocale:enUSPOSIXLocale];
     [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
-    [dateFormatter setTimeZone:[NSTimeZone systemTimeZone]];
+    [dateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
     NSString *timestamp = [dateFormatter stringFromDate:logMessage.timestamp];
     
     NSString *log = [NSString stringWithFormat:@"<%@>%@ %@ %@: %@ %@@%@@%lu \"%@\"", logLevel,


### PR DESCRIPTION
Timezone corrected

The timezone was set to the system timezone but not transferred to the server. There the timezone is added again. This means:
If you are in GMT +0200 the timestamp is wrong by 2 hours.